### PR TITLE
feat(#70): Include checks not to buy with an empty shopping cart

### DIFF
--- a/templates/base_CART.html
+++ b/templates/base_CART.html
@@ -65,8 +65,9 @@
 
     <div class="cart-footer">
         <div class="total-price"><span>Total:</span> <span>{{ total_price }} €</span></div>
-
+        {% if products %}
         <a href="{% url 'order' %}" class="btn btn-success">Realizar pedido</a>
+        {% endif %}
     </div>
 </div>
 

--- a/templates/base_ORDER.html
+++ b/templates/base_ORDER.html
@@ -21,6 +21,8 @@
 </ul>
 {% endif %}
 
+{% if cart_counter > 0 %}  
+
 <h1 class="heading">Introduce tus datos</h1>
 
 <form class="order-form row d-flex justify-content-around" action="/order/" method="post">
@@ -34,10 +36,15 @@
     <div class="form-submit col-4 d-flex align-items-end flex-column">
         <div class="total-price"><span>Total:</span> <span>{{ total_price }} €</span></div>
 
-        <div class="return-policy"><span><input type="checkbox" required>He leído y acepto la <a href="{% url 'return_policy' %}" target="_blank">política de devolución</a></span></div>
+        <div class="return-policy"><span><input type="checkbox" required>He leído y acepto la <a href="{% url 'return_policy' %}" target="_blank">política de devolución</a></span></div>  
         <button type="submit" class="btn btn-success">Procesar el pago</button>
     </div>
 </form>
 
+{% else %}
+<div class="alert alert-warning" role="alert">
+    Para acceder a esta página debe tener algún producto en su cesta.
+</div>
+{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
The button to go to the data form is not visible if the cart is empty. The data form prior to the purchase payment does not appear visible if the user does not have any objects in their shopping cart.